### PR TITLE
update Makefile to use `npx` to run `vsce` commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev:
 	npm install
 
 package: dev
-	vsce package
+	npx vsce package
 
 publish:
-	vsce publish
+	npx vsce publish


### PR DESCRIPTION
Updates the Makefile to use `npx` to run `vsce` commands since on my machine, `vsce` isn't on my $PATH.